### PR TITLE
cm: common: Remove Launcher3 makefile entry

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -161,7 +161,6 @@ PRODUCT_PACKAGES += \
     CyanogenSetupWizard \
     Eleven \
     ExactCalculator \
-    Launcher3 \
     LiveLockScreenService \
     LockClock \
     Screencast \


### PR DESCRIPTION
We no longer sync Launcher3. This entry never did anything anyway,
since we build Trebuchet instead, which overrides Launcher3.

Change-Id: Ia2c56c9f819025ba34cbff1daf8d3380a924a8a5